### PR TITLE
Fix bulk import upload JSON handling

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -40,11 +40,15 @@ app.use((req, res, next) => {
   const server = await registerRoutes(app);
 
   app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
-    const status = err.status || err.statusCode || 500;
-    const message = err.message || "Internal Server Error";
+    console.error(err);
+    if (res.headersSent) {
+      return;
+    }
 
-    res.status(status).json({ message });
-    throw err;
+    const status = err.status || err.statusCode || 500;
+    const message = err.message || "Internal server error";
+
+    res.status(status).json({ success: false, error: message });
   });
 
   // importantly only setup vite in development and after

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,5 +36,12 @@ export default defineConfig({
       strict: true,
       deny: ["**/.*"],
     },
+    // Proxy API calls to the Express server during local development so uploads hit the backend directly.
+    proxy: {
+      '/api': {
+        target: 'http://localhost:5000',
+        changeOrigin: true,
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary
- ensure the bulk upload wizard only parses JSON responses and surfaces clear success/error toasts
- add a memory-backed Express bulk upload endpoint that validates uploads, persists the file, and always returns JSON
- return JSON for unknown API routes and configure the Vite dev proxy so API calls hit the backend in development

## Testing
- npm run check *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ead26c9528832d9ae1ddf26b7e1b96