### PR TITLE
fix(analytics): enable CSV exports for Cases Over Time and Tumour Type Distribution (reusable exporter, a11y, Lagos date suffix)

### DIFF
--- a/client/src/lib/export.ts
+++ b/client/src/lib/export.ts
@@ -1,0 +1,60 @@
+export type CsvHeader = {
+  key: string;
+  label: string;
+};
+
+export type CsvRow = Record<string, unknown>;
+
+const formatDateForLagos = () => {
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Africa/Lagos",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+
+  return formatter.format(new Date());
+};
+
+const escapeCsvValue = (value: unknown): string => {
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  const stringValue = String(value);
+  const shouldQuote = /[",\n]/.test(stringValue);
+  const escapedValue = stringValue.replace(/"/g, '""');
+
+  return shouldQuote ? `"${escapedValue}"` : escapedValue;
+};
+
+export interface ExportToCsvOptions {
+  rows: CsvRow[];
+  headers: CsvHeader[];
+  filename: string;
+}
+
+export const exportToCsv = ({ rows, headers, filename }: ExportToCsvOptions) => {
+  if (!headers.length) {
+    throw new Error("CSV export requires at least one header");
+  }
+
+  const headerLine = headers.map((header) => escapeCsvValue(header.label)).join(",");
+  const dataLines = rows.map((row) =>
+    headers.map((header) => escapeCsvValue(row[header.key])).join(",")
+  );
+
+  const csvContent = [headerLine, ...dataLines].join("\n");
+  const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+
+  const dateSuffix = formatDateForLagos();
+  const link = document.createElement("a");
+  link.href = url;
+  link.setAttribute("download", `${filename}_${dateSuffix}.csv`);
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+
+  URL.revokeObjectURL(url);
+};

--- a/client/src/pages/analytics.tsx
+++ b/client/src/pages/analytics.tsx
@@ -3,11 +3,14 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart, Pie, Cell, LineChart, Line } from "recharts";
+import { useToast } from "@/hooks/use-toast";
+import { exportToCsv } from "@/lib/export";
 import type { DashboardStats } from "@/lib/types";
 
 const COLORS = ['hsl(var(--primary))', 'hsl(var(--accent))', 'hsl(var(--secondary))', 'hsl(var(--chart-4))', 'hsl(var(--chart-5))'];
 
 export default function Analytics() {
+  const { toast } = useToast();
   const { data: stats, isLoading, error } = useQuery<DashboardStats>({
     queryKey: ["/api/dashboard/stats"],
   });
@@ -54,6 +57,69 @@ export default function Analytics() {
       </div>
     );
   }
+
+  const casesOverTimeRows = stats.casesByMonth.map((item) => ({
+    period: item.month,
+    cases: item.count,
+  }));
+  const hasCasesOverTimeData = casesOverTimeRows.length > 0;
+
+  const tumourDistributionTotal = stats.topTumourTypes.reduce((total, item) => total + item.count, 0);
+  const tumourDistributionRows = stats.topTumourTypes.map((item) => ({
+    tumour_type: item.name,
+    cases: item.count,
+    percent: tumourDistributionTotal > 0 ? `${Math.round((item.count / tumourDistributionTotal) * 100)}%` : "",
+  }));
+  const hasTumourDistributionData = tumourDistributionRows.length > 0;
+
+  const handleCasesOverTimeExport = () => {
+    if (!hasCasesOverTimeData) {
+      return;
+    }
+
+    try {
+      exportToCsv({
+        rows: casesOverTimeRows,
+        headers: [
+          { key: "period", label: "period" },
+          { key: "cases", label: "cases" },
+        ],
+        filename: "cases-over-time",
+      });
+    } catch (err) {
+      console.error(err);
+      toast({
+        variant: "destructive",
+        title: "Export failed",
+        description: "We couldn't export the Cases Over Time data. Please try again.",
+      });
+    }
+  };
+
+  const handleTumourDistributionExport = () => {
+    if (!hasTumourDistributionData) {
+      return;
+    }
+
+    try {
+      exportToCsv({
+        rows: tumourDistributionRows,
+        headers: [
+          { key: "tumour_type", label: "tumour_type" },
+          { key: "cases", label: "cases" },
+          { key: "percent", label: "percent" },
+        ],
+        filename: "tumour-type-distribution",
+      });
+    } catch (err) {
+      console.error(err);
+      toast({
+        variant: "destructive",
+        title: "Export failed",
+        description: "We couldn't export the Tumour Type Distribution data. Please try again.",
+      });
+    }
+  };
 
   return (
     <div className="p-4 sm:p-6">
@@ -108,7 +174,18 @@ export default function Analytics() {
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
             <CardTitle>Cases Over Time</CardTitle>
-            <Button variant="outline" size="sm" data-testid="button-export-trend-chart">
+            <Button
+              variant="outline"
+              size="sm"
+              data-testid="button-export-trend-chart"
+              onClick={handleCasesOverTimeExport}
+              disabled={!hasCasesOverTimeData}
+              aria-label={
+                hasCasesOverTimeData
+                  ? "Export Cases Over Time as CSV"
+                  : "No Cases Over Time data to export"
+              }
+            >
               <i className="fas fa-download mr-2"></i>Export
             </Button>
           </CardHeader>
@@ -146,7 +223,18 @@ export default function Analytics() {
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
             <CardTitle>Tumour Type Distribution</CardTitle>
-            <Button variant="outline" size="sm" data-testid="button-export-distribution-chart">
+            <Button
+              variant="outline"
+              size="sm"
+              data-testid="button-export-distribution-chart"
+              onClick={handleTumourDistributionExport}
+              disabled={!hasTumourDistributionData}
+              aria-label={
+                hasTumourDistributionData
+                  ? "Export Tumour Type Distribution as CSV"
+                  : "No tumour type distribution data to export"
+              }
+            >
               <i className="fas fa-download mr-2"></i>Export
             </Button>
           </CardHeader>


### PR DESCRIPTION
## Summary
- add a shared CSV export utility that generates Lagos-date filenames and quotes data
- enable the Cases Over Time export button with normalized rows, accessibility, and toast errors
- enable the Tumour Type Distribution export button with percent column handling and consistent UX states

## Testing
- npm run check *(fails: pre-existing type errors in cases page and server storage)*

------
https://chatgpt.com/codex/tasks/task_e_68eb7e56900c832d8465c0325b8927b2