### PR TITLE
fix(analytics): harden CSV export reliability

### DIFF
--- a/client/src/lib/export.ts
+++ b/client/src/lib/export.ts
@@ -1,0 +1,78 @@
+export type CsvHeader = {
+  key: string;
+  label: string;
+};
+
+export type CsvRow = Record<string, unknown>;
+
+const formatDateForLagos = () => {
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Africa/Lagos",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+
+  return formatter.format(new Date());
+};
+
+const escapeCsvValue = (value: unknown): string => {
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  const stringValue = String(value);
+  const shouldQuote = /[",\n\r]/.test(stringValue);
+  const escapedValue = stringValue.replace(/"/g, '""');
+
+  return shouldQuote ? `"${escapedValue}"` : escapedValue;
+};
+
+export interface ExportToCsvOptions {
+  rows: CsvRow[];
+  headers: CsvHeader[];
+  filename: string;
+}
+
+export const exportToCsv = ({ rows, headers, filename }: ExportToCsvOptions) => {
+  if (!headers.length) {
+    throw new Error("CSV export requires at least one header");
+  }
+
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    throw new Error("CSV export is only available in the browser");
+  }
+
+  const headerLine = headers.map((header) => escapeCsvValue(header.label)).join(",");
+  const dataLines = rows.map((row) =>
+    headers.map((header) => escapeCsvValue(row[header.key])).join(",")
+  );
+
+  const newline = "\r\n";
+  const csvContent = [headerLine, ...dataLines].join(newline);
+  const blobContent = `\ufeff${csvContent}`;
+  const blob = new Blob([blobContent], { type: "text/csv;charset=utf-8;" });
+  const dateSuffix = formatDateForLagos();
+  const filenameWithDate = `${filename}_${dateSuffix}.csv`;
+  const link = document.createElement("a");
+  link.setAttribute("download", filenameWithDate);
+
+  const navigatorWithSave = window.navigator as Navigator & {
+    msSaveOrOpenBlob?: (blob: Blob, defaultName?: string) => boolean;
+  };
+
+  if (typeof navigatorWithSave.msSaveOrOpenBlob === "function") {
+    navigatorWithSave.msSaveOrOpenBlob(blob, filenameWithDate);
+    return;
+  }
+
+  const url = URL.createObjectURL(blob);
+  link.href = url;
+  try {
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+};


### PR DESCRIPTION
## Summary
- add a shared CSV export utility that generates Lagos-date filenames and quotes data
- enable the Cases Over Time export button with normalized rows, accessibility, and toast errors
- enable the Tumour Type Distribution export button with percent column handling and consistent UX states
- harden the export helper for legacy browser support, BOM-prefixed output, and CRLF newlines for spreadsheet apps

## Testing
- npm run check *(fails: pre-existing type errors in cases page and server storage)*

------
https://chatgpt.com/codex/tasks/task_e_68eb7e56900c832d8465c0325b8927b2