### PR TITLE
Add analytics date range switcher with URL persistence

### DIFF
--- a/client/src/components/analytics/date-range-switcher.tsx
+++ b/client/src/components/analytics/date-range-switcher.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useMemo, useState } from "react";
+import { CalendarRange, ChevronDown } from "lucide-react";
+import type { DateRange } from "react-day-picker";
+
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+import { useAnalyticsDateRange } from "@/contexts/analytics-date-range-context";
+import type { AnalyticsDateRangePreset } from "@/lib/analytics-date-range";
+
+const presets: Array<{ value: AnalyticsDateRangePreset; label: string; helper: string }> = [
+  { value: "last30d", label: "Last 30 days", helper: "Including today" },
+  { value: "last90d", label: "Last 90 days", helper: "Default" },
+  { value: "ytd", label: "Year to date", helper: "From Jan 1" },
+  { value: "custom", label: "Custom range", helper: "Choose start & end" },
+];
+
+function formatDateForInput(date: Date): string {
+  const year = date.getFullYear();
+  const month = (date.getMonth() + 1).toString().padStart(2, "0");
+  const day = date.getDate().toString().padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+export function DateRangeSwitcher() {
+  const { label, preset, setPreset, setCustomRange, customStart, customEnd } = useAnalyticsDateRange();
+  const [open, setOpen] = useState(false);
+  const [rangeDraft, setRangeDraft] = useState<DateRange | undefined>(undefined);
+  const [validationMessage, setValidationMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (preset === "custom" && customStart && customEnd) {
+      setRangeDraft({ from: new Date(`${customStart}T00:00:00`), to: new Date(`${customEnd}T00:00:00`) });
+    } else {
+      setRangeDraft(undefined);
+      setValidationMessage(null);
+    }
+  }, [preset, customStart, customEnd]);
+
+  useEffect(() => {
+    if (preset !== "custom") {
+      return;
+    }
+
+    const { from, to } = rangeDraft ?? {};
+
+    if (!from || !to) {
+      return;
+    }
+
+    if (from > to) {
+      setValidationMessage("Start date must be before end date.");
+      return;
+    }
+
+    setValidationMessage(null);
+    const timeout = window.setTimeout(() => {
+      const start = formatDateForInput(from);
+      const end = formatDateForInput(to);
+      setCustomRange(start, end);
+    }, 250);
+
+    return () => window.clearTimeout(timeout);
+  }, [preset, rangeDraft, setCustomRange]);
+
+  const activeHelper = useMemo(() => presets.find((item) => item.value === preset)?.helper ?? "", [preset]);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          className="h-10 gap-2 rounded-full border-border/80 bg-background px-4 text-sm font-medium shadow-sm hover:bg-accent"
+        >
+          <CalendarRange className="h-4 w-4" />
+          <span className="text-xs uppercase tracking-wide text-muted-foreground">Date range</span>
+          <Separator orientation="vertical" className="h-4" />
+          <span className="text-sm text-foreground">{label}</span>
+          <ChevronDown className="ml-1 h-4 w-4 text-muted-foreground" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[320px] p-4" align="start">
+        <div className="space-y-4">
+          <div>
+            <p className="text-sm font-semibold text-foreground">Analytics date range</p>
+            <p className="text-xs text-muted-foreground">{activeHelper}</p>
+          </div>
+          <RadioGroup
+            value={preset}
+            onValueChange={(value) => {
+              const typedValue = value as AnalyticsDateRangePreset;
+              setPreset(typedValue);
+              if (typedValue !== "custom") {
+                setOpen(false);
+              }
+            }}
+            className="grid gap-2"
+          >
+            {presets.map((item) => (
+              <Label
+                key={item.value}
+                htmlFor={`analytics-date-${item.value}`}
+                className={cn(
+                  "flex cursor-pointer items-center justify-between rounded-md border p-3 text-sm transition",
+                  preset === item.value ? "border-primary bg-primary/10" : "border-border hover:border-primary/60"
+                )}
+              >
+                <div className="flex flex-col">
+                  <span className="font-medium text-foreground">{item.label}</span>
+                  <span className="text-xs text-muted-foreground">{item.helper}</span>
+                </div>
+                <RadioGroupItem id={`analytics-date-${item.value}`} value={item.value} />
+              </Label>
+            ))}
+          </RadioGroup>
+
+          {preset === "custom" ? (
+            <div className="space-y-2 rounded-md border border-dashed p-3">
+              <Calendar
+                initialFocus
+                mode="range"
+                selected={rangeDraft}
+                numberOfMonths={1}
+                onSelect={(value) => setRangeDraft(value ?? undefined)}
+              />
+              {validationMessage ? (
+                <p className="text-xs text-destructive">{validationMessage}</p>
+              ) : (
+                <p className="text-xs text-muted-foreground">Pick a start and end date in Africa/Lagos time.</p>
+              )}
+            </div>
+          ) : null}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+

--- a/client/src/contexts/analytics-date-range-context.tsx
+++ b/client/src/contexts/analytics-date-range-context.tsx
@@ -1,0 +1,127 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+import { useLocation } from "wouter";
+
+import {
+  AnalyticsDateRangePreset,
+  ResolvedAnalyticsDateRange,
+  parseAnalyticsDateRange,
+  resolveAnalyticsDateRange,
+} from "@/lib/analytics-date-range";
+
+interface AnalyticsDateRangeRequestState {
+  preset: AnalyticsDateRangePreset;
+  customStart?: string;
+  customEnd?: string;
+}
+
+interface AnalyticsDateRangeContextValue extends ResolvedAnalyticsDateRange {
+  customStart?: string;
+  customEnd?: string;
+  setPreset: (preset: AnalyticsDateRangePreset) => void;
+  setCustomRange: (start: string, end: string) => void;
+}
+
+const AnalyticsDateRangeContext = createContext<AnalyticsDateRangeContextValue | undefined>(undefined);
+
+function extractPathAndSearch(location: string): { path: string; search: string } {
+  const [path, search = ""] = location.split("?");
+  return { path, search };
+}
+
+export function AnalyticsDateRangeProvider({ children }: { children: ReactNode }) {
+  const [location, setLocation] = useLocation();
+
+  const [requestState, setRequestState] = useState<AnalyticsDateRangeRequestState>(() => {
+    const { search } = extractPathAndSearch(location);
+    const params = new URLSearchParams(search);
+    return parseAnalyticsDateRange(params);
+  });
+
+  useEffect(() => {
+    const { search } = extractPathAndSearch(location);
+    const params = new URLSearchParams(search);
+    const parsed = parseAnalyticsDateRange(params);
+    setRequestState((prev) => {
+      if (
+        prev.preset === parsed.preset &&
+        prev.customStart === parsed.customStart &&
+        prev.customEnd === parsed.customEnd
+      ) {
+        return prev;
+      }
+
+      return {
+        preset: parsed.preset,
+        customStart: parsed.customStart ?? prev.customStart,
+        customEnd: parsed.customEnd ?? prev.customEnd,
+      };
+    });
+  }, [location]);
+
+  const resolved = useMemo<ResolvedAnalyticsDateRange>(() => {
+    return resolveAnalyticsDateRange(requestState.preset, requestState.customStart, requestState.customEnd);
+  }, [requestState]);
+
+  useEffect(() => {
+    const { path, search } = extractPathAndSearch(location);
+    const params = new URLSearchParams(search);
+
+    params.set("range", resolved.preset);
+
+    if (resolved.preset === "custom") {
+      params.set("start", resolved.startDate);
+      params.set("end", resolved.endDate);
+    } else {
+      params.delete("start");
+      params.delete("end");
+    }
+
+    const queryString = params.toString();
+    const nextLocation = queryString ? `${path}?${queryString}` : path;
+
+    if (nextLocation !== location) {
+      setLocation(nextLocation, { replace: true });
+    }
+  }, [resolved, location, setLocation]);
+
+  const setPreset = useCallback(
+    (preset: AnalyticsDateRangePreset) => {
+      setRequestState((prev) => ({
+        preset,
+        customStart: prev.customStart,
+        customEnd: prev.customEnd,
+      }));
+    },
+    []
+  );
+
+  const setCustomRange = useCallback((start: string, end: string) => {
+    setRequestState((prev) => ({
+      preset: "custom",
+      customStart: start,
+      customEnd: end,
+    }));
+  }, []);
+
+  const value = useMemo<AnalyticsDateRangeContextValue>(
+    () => ({
+      ...resolved,
+      customStart: requestState.customStart,
+      customEnd: requestState.customEnd,
+      setPreset,
+      setCustomRange,
+    }),
+    [resolved, requestState.customStart, requestState.customEnd, setPreset, setCustomRange]
+  );
+
+  return <AnalyticsDateRangeContext.Provider value={value}>{children}</AnalyticsDateRangeContext.Provider>;
+}
+
+export function useAnalyticsDateRange() {
+  const context = useContext(AnalyticsDateRangeContext);
+  if (!context) {
+    throw new Error("useAnalyticsDateRange must be used within an AnalyticsDateRangeProvider");
+  }
+  return context;
+}
+

--- a/client/src/lib/analytics-date-range.ts
+++ b/client/src/lib/analytics-date-range.ts
@@ -1,0 +1,196 @@
+import { useMemo } from "react";
+
+export const LAGOS_TIME_ZONE = "Africa/Lagos";
+const LAGOS_OFFSET_MINUTES = 60; // Africa/Lagos is UTC+1 without DST
+
+export type AnalyticsDateRangePreset = "last30d" | "last90d" | "ytd" | "custom";
+
+export interface LagosDateParts {
+  year: number;
+  month: number;
+  day: number;
+}
+
+export interface ResolvedAnalyticsDateRange {
+  preset: AnalyticsDateRangePreset;
+  startParts: LagosDateParts;
+  endParts: LagosDateParts;
+  startDate: string; // YYYY-MM-DD in Lagos timezone
+  endDate: string; // YYYY-MM-DD in Lagos timezone
+  startISO: string; // ISO string converted to UTC boundary
+  endISO: string; // ISO string converted to UTC boundary
+  label: string;
+}
+
+const lagosDateFormatter = new Intl.DateTimeFormat("en-CA", {
+  timeZone: LAGOS_TIME_ZONE,
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+
+const lagosDisplayDayFormatter = new Intl.DateTimeFormat("en-US", {
+  timeZone: LAGOS_TIME_ZONE,
+  month: "short",
+  day: "numeric",
+});
+
+const lagosDisplayFullFormatter = new Intl.DateTimeFormat("en-US", {
+  timeZone: LAGOS_TIME_ZONE,
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+});
+
+function parseFormatterParts(date: Date): LagosDateParts {
+  const formatted = lagosDateFormatter.format(date);
+  const [year, month, day] = formatted.split("-").map(Number);
+  return { year, month, day };
+}
+
+function lagosDatePartsToUtcDate(parts: LagosDateParts, hours = 0, minutes = 0, seconds = 0): Date {
+  return new Date(Date.UTC(parts.year, parts.month - 1, parts.day, hours, minutes, seconds) - LAGOS_OFFSET_MINUTES * 60 * 1000);
+}
+
+function toDateString(parts: LagosDateParts): string {
+  return `${parts.year.toString().padStart(4, "0")}-${parts.month.toString().padStart(2, "0")}-${parts.day
+    .toString()
+    .padStart(2, "0")}`;
+}
+
+function adjustParts(parts: LagosDateParts, deltaDays: number): LagosDateParts {
+  const base = new Date(Date.UTC(parts.year, parts.month - 1, parts.day));
+  base.setUTCDate(base.getUTCDate() + deltaDays);
+  return {
+    year: base.getUTCFullYear(),
+    month: base.getUTCMonth() + 1,
+    day: base.getUTCDate(),
+  };
+}
+
+function getLagosTodayParts(): LagosDateParts {
+  return parseFormatterParts(new Date());
+}
+
+function formatRangeLabel(startParts: LagosDateParts, endParts: LagosDateParts): string {
+  const startDisplayDate = lagosDatePartsToUtcDate(startParts, 12);
+  const endDisplayDate = lagosDatePartsToUtcDate(endParts, 12);
+
+  const sameDay =
+    startParts.year === endParts.year && startParts.month === endParts.month && startParts.day === endParts.day;
+  const sameYear = startParts.year === endParts.year;
+
+  if (sameDay) {
+    return `${lagosDisplayFullFormatter.format(startDisplayDate)}`;
+  }
+
+  if (sameYear) {
+    const startLabel = lagosDisplayDayFormatter.format(startDisplayDate);
+    const endLabel = lagosDisplayDayFormatter.format(endDisplayDate);
+    return `${startLabel}–${endLabel}, ${startParts.year}`;
+  }
+
+  const startFull = lagosDisplayFullFormatter.format(startDisplayDate);
+  const endFull = lagosDisplayFullFormatter.format(endDisplayDate);
+  return `${startFull} – ${endFull}`;
+}
+
+function resolvePreset(
+  preset: AnalyticsDateRangePreset,
+  customStart?: string,
+  customEnd?: string
+): ResolvedAnalyticsDateRange {
+  let startParts: LagosDateParts;
+  let endParts: LagosDateParts;
+
+  if (preset === "custom" && customStart && customEnd) {
+    const [startYear, startMonth, startDay] = customStart.split("-").map(Number);
+    const [endYear, endMonth, endDay] = customEnd.split("-").map(Number);
+    startParts = { year: startYear, month: startMonth, day: startDay };
+    endParts = { year: endYear, month: endMonth, day: endDay };
+  } else {
+    const today = getLagosTodayParts();
+    switch (preset) {
+      case "last30d": {
+        endParts = today;
+        startParts = adjustParts(endParts, -29);
+        break;
+      }
+      case "ytd": {
+        endParts = today;
+        startParts = { year: today.year, month: 1, day: 1 };
+        break;
+      }
+      case "custom":
+      case "last90d":
+      default: {
+        endParts = today;
+        startParts = adjustParts(endParts, -89);
+        break;
+      }
+    }
+  }
+
+  const startISO = lagosDatePartsToUtcDate(startParts, 0, 0, 0).toISOString();
+  const endISO = lagosDatePartsToUtcDate(endParts, 23, 59, 59).toISOString();
+  return {
+    preset,
+    startParts,
+    endParts,
+    startDate: toDateString(startParts),
+    endDate: toDateString(endParts),
+    startISO,
+    endISO,
+    label: formatRangeLabel(startParts, endParts),
+  };
+}
+
+export function parseAnalyticsDateRange(searchParams: URLSearchParams): {
+  preset: AnalyticsDateRangePreset;
+  customStart?: string;
+  customEnd?: string;
+} {
+  const presetParam = (searchParams.get("range") as AnalyticsDateRangePreset) || "last90d";
+
+  if (presetParam === "custom") {
+    const start = searchParams.get("start") || undefined;
+    const end = searchParams.get("end") || undefined;
+    if (start && end) {
+      return { preset: "custom", customStart: start, customEnd: end };
+    }
+  }
+
+  if (presetParam === "last30d" || presetParam === "ytd" || presetParam === "custom") {
+    return { preset: presetParam };
+  }
+
+  return { preset: "last90d" };
+}
+
+export function resolveAnalyticsDateRange(
+  preset: AnalyticsDateRangePreset,
+  customStart?: string,
+  customEnd?: string
+): ResolvedAnalyticsDateRange {
+  const resolved = resolvePreset(preset, customStart, customEnd);
+
+  if (resolved.preset === "custom") {
+    const startTime = lagosDatePartsToUtcDate(resolved.startParts, 0, 0, 0).getTime();
+    const endTime = lagosDatePartsToUtcDate(resolved.endParts, 23, 59, 59).getTime();
+    if (startTime > endTime) {
+      // Invalid custom range - fall back to default preset
+      return resolvePreset("last90d");
+    }
+  }
+
+  return resolved;
+}
+
+export function useResolvedAnalyticsRange(
+  preset: AnalyticsDateRangePreset,
+  customStart?: string,
+  customEnd?: string
+) {
+  return useMemo(() => resolveAnalyticsDateRange(preset, customStart, customEnd), [preset, customStart, customEnd]);
+}
+


### PR DESCRIPTION
## Summary
- add a dedicated analytics date range context that normalises Lagos time and syncs selection with URL query params
- introduce a Date Range Switcher component with presets, custom calendar range, and validation feedback
- update the analytics page to consume the shared range, refresh queries, adjust exports, and show zero-state messaging when the window has no data

## Testing
- npm run check *(fails: existing TypeScript errors in legacy routes/storage and exports utilities)*

------
https://chatgpt.com/codex/tasks/task_e_68ec061ac6d8832d803c696acf1d0066